### PR TITLE
add test file to test firebase connection

### DIFF
--- a/VehicalBlackBox/Test-firebase-connection/Test-firebase-connection.ino
+++ b/VehicalBlackBox/Test-firebase-connection/Test-firebase-connection.ino
@@ -1,0 +1,40 @@
+#include <ESP8266WiFi.h>
+#include <FirebaseESP8266.h>
+
+#define WIFI_SSID "POCO M3"
+#define WIFI_PASSWORD "12345678"
+
+#define FIREBASE_HOST "----------------------"
+#define FIREBASE_AUTH "----------------------"
+
+FirebaseData firebaseData;
+FirebaseConfig config;
+FirebaseAuth auth;
+
+void setup() {
+  Serial.begin(9600);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  Serial.print("Connecting to Wi-Fi");
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println(" connected!");
+
+  // Configure Firebase
+  config.host = FIREBASE_HOST;
+  config.signer.tokens.legacy_token = FIREBASE_AUTH;
+  
+  Firebase.begin(&config, &auth);
+  Firebase.reconnectWiFi(true);
+
+  if (Firebase.setString(firebaseData, "/message", "Hello, world")) {
+    Serial.println("Message sent!");
+  } else {
+    Serial.print("Firebase error: ");
+    Serial.println(firebaseData.errorReason());
+  }
+}
+
+void loop() {
+}


### PR DESCRIPTION
This test file verifies connectivity to Firebase by sending a "Hello World" message to your Firebase Realtime Database.

Important notes --------- THIS IS FOR TESTING FIREBASE CONNECTION ONLY

FIREBASE_HOST and FIREBASE_AUTH are intentionally left blank.
Replace them with your actual Firebase credentials before testing
Update WIFI_SSID and WIFI_PASSWORD with your network details.
